### PR TITLE
EMBED-903 Demonstrate context data usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,19 @@ in the sample manifest contained repository.
 
 ## Demoed Extension Features
 
+### Context Functions
+
+Extensions can share context data between users. The context data can be used for data that does not change frequently and to share amongst different users of the extension. Care should be taken when writing the data as there is no data locking and the last write wins. The context data is available to the extension immediately. Functions are provided to write and refresh the data.
+
+- `getContextData` - get the context data.
+- `saveContextData` - writes context data to the Looker server.
+- `refreshContextData` - gets the lastest context data from the Looker server.
+
+The configuation component demonstrates the context functionality. It can be used to show/hide views in the Kitchen Sink. It can also be used to change the keys used for the embed demonstrations.
+
 ### API Functions
 
-API functions demonstrates the following function
+API functions demonstrates the following functionality
 
 - Update title - modifies the title of the page the extension is running in.
 - Navigation - navigates to different locations in the Looker server using the current page (browse and marketplace).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extension-template-kitchensink",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "Looker Extension SDK functionality demonstration",
   "main": "dist/bundle.js",
   "scripts": {
@@ -20,8 +20,8 @@
     "@hot-loader/react-dom": "^16.13.0",
     "@looker/components": "0.9.6",
     "@looker/embed-sdk": "1.0.0-beta.6",
-    "@looker/extension-sdk": "^0.10.5",
-    "@looker/extension-sdk-react": "^0.6.1",
+    "@looker/extension-sdk": "^0.11.0",
+    "@looker/extension-sdk-react": "^0.6.2",
     "@looker/sdk": "0.3.0-beta.1",
     "@types/node": "^12.7.5",
     "@types/react": "^16.9.25",

--- a/server/index.js
+++ b/server/index.js
@@ -103,7 +103,7 @@ server.post('/auth', async (req, res) => {
   const { type, expires_in, name, id, client_secret } = req.body
   // validate the client secret
   if (client_secret !== process.env.CUSTOM_CLIENT_SECRET) {
-    res.status(401)
+    res.sendStatus(401)
     return
   }
   // In theory the id would be used to check if the user is

--- a/src/KitchenSink.tsx
+++ b/src/KitchenSink.tsx
@@ -1,0 +1,165 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Looker Data Sciences, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import React, { useState, useContext } from 'react'
+import { Switch, Route } from 'react-router-dom'
+import styled from 'styled-components'
+import { Box, ComponentsProvider, MessageBar } from '@looker/components'
+import {
+  ExtensionContext,
+  ExtensionContextData,
+} from '@looker/extension-sdk-react'
+import { Sidebar } from './components/Sidebar'
+import { CoreSDKFunctions } from './components/CoreSDKFunctions'
+import { ApiFunctions } from './components/ApiFunctions'
+import { Home } from './components/Home'
+import { EmbedDashboard } from './components/Embed'
+import { EmbedExplore } from './components/Embed/EmbedExplore'
+import { EmbedLook } from './components/Embed/EmbedLook'
+import { ExternalApiFunctions } from './components/ExternalApiFunctions'
+import { MiscFunctions } from './components/MiscFunctions'
+import { Configure } from './components/Configure'
+import { KitchenSinkProps, ConfigurationData } from './types'
+
+export enum ROUTES {
+  HOME_ROUTE = '/',
+  API_ROUTE = '/api',
+  CORESDK_ROUTE = '/coresdk',
+  EMBED_DASHBOARD = '/embed/dashboard',
+  EMBED_EXPLORE = '/embed/explore',
+  EMBED_LOOK = '/embed/look',
+  EXTERNAL_API_ROUTE = '/externalapi',
+  MISC_ROUTE = '/misc',
+  CONFIG_ROUTE = '/config',
+}
+
+export const KitchenSink: React.FC<KitchenSinkProps> = ({
+  route,
+  routeState,
+}) => {
+  const extensionContext = useContext<ExtensionContextData>(ExtensionContext)
+  const { extensionSDK, initializeError } = extensionContext
+  const [configurationData, setConfigurationData] = useState<ConfigurationData>(
+    extensionSDK.getContextData() || {
+      showApiFunctions: true,
+      showCoreSdkFunctions: true,
+      showEmbedDashboard: true,
+      showEmbedExplore: true,
+      showEmbedLook: true,
+      showExternalApiFunctions: true,
+      showMiscFunctions: true,
+      dashboardId: 1,
+      exploreId: 'thelook/products',
+      lookId: 1,
+    }
+  )
+
+  const updateConfigurationData = async (
+    configurationData: ConfigurationData
+  ): Promise<boolean> => {
+    setConfigurationData(configurationData)
+    try {
+      await extensionSDK.saveContextData(configurationData)
+      return true
+    } catch (error) {
+      return false
+    }
+  }
+
+  return (
+    <ComponentsProvider>
+      {initializeError ? (
+        <MessageBar intent="critical">{initializeError}</MessageBar>
+      ) : (
+        <Layout>
+          <Sidebar
+            route={route}
+            routeState={routeState}
+            configurationData={configurationData}
+          />
+          <Box>
+            <Switch>
+              {configurationData.showApiFunctions && (
+                <Route path={ROUTES.API_ROUTE}>
+                  <ApiFunctions />
+                </Route>
+              )}
+              {configurationData.showCoreSdkFunctions && (
+                <Route
+                  path={[
+                    ROUTES.CORESDK_ROUTE,
+                    `${ROUTES.CORESDK_ROUTE}?test=abcd`,
+                  ]}
+                >
+                  <CoreSDKFunctions />
+                </Route>
+              )}
+              {configurationData.showEmbedDashboard && (
+                <Route path={ROUTES.EMBED_DASHBOARD}>
+                  <EmbedDashboard id={configurationData.dashboardId} />
+                </Route>
+              )}
+              {configurationData.showEmbedExplore && (
+                <Route path={ROUTES.EMBED_EXPLORE}>
+                  <EmbedExplore id={configurationData.exploreId} />
+                </Route>
+              )}
+              {configurationData.showEmbedLook && (
+                <Route path={ROUTES.EMBED_LOOK}>
+                  <EmbedLook id={configurationData.lookId} />
+                </Route>
+              )}
+              {configurationData.showExternalApiFunctions && (
+                <Route path={ROUTES.EXTERNAL_API_ROUTE}>
+                  <ExternalApiFunctions />
+                </Route>
+              )}
+              {configurationData.showMiscFunctions && (
+                <Route path={ROUTES.MISC_ROUTE}>
+                  <MiscFunctions />
+                </Route>
+              )}
+              <Route path={ROUTES.CONFIG_ROUTE}>
+                <Configure
+                  configurationData={configurationData}
+                  updateConfigurationData={updateConfigurationData}
+                />
+              </Route>
+              <Route>
+                <Home />
+              </Route>
+            </Switch>
+          </Box>
+        </Layout>
+      )}
+    </ComponentsProvider>
+  )
+}
+
+export const Layout = styled(Box)`
+  display: grid;
+  grid-gap: 20px;
+  grid-template-columns: 200px auto;
+  width: 100vw;
+`

--- a/src/components/ApiFunctions/ApiFunctions.tsx
+++ b/src/components/ApiFunctions/ApiFunctions.tsx
@@ -22,28 +22,27 @@
  * THE SOFTWARE.
  */
 
-import React, { useContext, useState } from "react"
+import React, { useContext, useState } from 'react'
 import { useHistory } from 'react-router-dom'
-import { Heading, Box } from "@looker/components"
-import styled from "styled-components"
-import { ExtensionButton } from "../ExtensionButton"
-import { SandboxStatus } from "../SandboxStatus"
-import { ApiFunctionsProps } from "./types"
+import { Heading, Box } from '@looker/components'
+import styled from 'styled-components'
+import { ExtensionButton } from '../ExtensionButton'
+import { SandboxStatus } from '../SandboxStatus'
+import { ApiFunctionsProps } from './types'
 import {
   ExtensionContext,
-  ExtensionContextData
-} from "@looker/extension-sdk-react"
-import { ExtensionHostApi } from "@looker/extension-sdk"
-import { ROUTES } from '../../App'
+  ExtensionContextData,
+} from '@looker/extension-sdk-react'
+import { ROUTES } from '../../KitchenSink'
 
 export const ApiFunctions: React.FC<ApiFunctionsProps> = () => {
   const history = useHistory()
-  const [messages, setMessages] = useState("")
+  const [messages, setMessages] = useState('')
   const extensionContext = useContext<ExtensionContextData>(ExtensionContext)
-  const extensionHost = extensionContext.extensionSDK as ExtensionHostApi
+  const { extensionSDK } = extensionContext
 
   const updateMessages = (message: string) => {
-    setMessages(prevMessages => {
+    setMessages((prevMessages) => {
       const maybeLineBreak = prevMessages.length === 0 ? '' : '\n'
       return `${prevMessages}${maybeLineBreak}${message}`
     })
@@ -51,45 +50,45 @@ export const ApiFunctions: React.FC<ApiFunctionsProps> = () => {
 
   const verifyHostConnectionClick = async () => {
     try {
-      const value = await extensionHost.verifyHostConnection()
+      const value = await extensionSDK.verifyHostConnection()
       if (value === true) {
-        updateMessages("Host verification success")
+        updateMessages('Host verification success')
       } else {
-        updateMessages("Invalid response " + value)
+        updateMessages('Invalid response ' + value)
       }
-    } catch(error) {
-      updateMessages("Host verification failure")
+    } catch (error) {
+      updateMessages('Host verification failure')
       updateMessages(error)
-      console.error("Host verification failure", error)
+      console.error('Host verification failure', error)
     }
   }
 
   const updateTitleButtonClick = () => {
     const date = new Date()
-    extensionHost.updateTitle(
+    extensionSDK.updateTitle(
       `Extension Title Update ${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}`
     )
-    updateMessages("Title updated")
+    updateMessages('Title updated')
   }
 
   const goToBrowseButtonClick = () => {
-    extensionHost.updateLocation("/browse")
+    extensionSDK.updateLocation('/browse')
   }
 
   const goToMarketplaceButtonClick = () => {
-    extensionHost.updateLocation("/marketplace")
+    extensionSDK.updateLocation('/marketplace')
   }
 
   const openMarketplaceButtonClick = () => {
-    extensionHost.openBrowserWindow("/marketplace", "_marketplace")
-    updateMessages("Window opened")
+    extensionSDK.openBrowserWindow('/marketplace', '_marketplace')
+    updateMessages('Window opened')
   }
 
   const localStorageSet = async () => {
     try {
-      await extensionHost.localStorageSetItem("testbed", new Date().toString())
-      updateMessages("Success")
-    } catch(error) {
+      await extensionSDK.localStorageSetItem('testbed', new Date().toString())
+      updateMessages('Success')
+    } catch (error) {
       updateMessages(error)
       console.error(error)
     }
@@ -97,9 +96,9 @@ export const ApiFunctions: React.FC<ApiFunctionsProps> = () => {
 
   const localStorageGet = async () => {
     try {
-      const value = await extensionHost.localStorageGetItem("testbed")
-      updateMessages(value || "null")
-    } catch(error) {
+      const value = await extensionSDK.localStorageGetItem('testbed')
+      updateMessages(value || 'null')
+    } catch (error) {
       updateMessages(error)
       console.error(error)
     }
@@ -107,24 +106,24 @@ export const ApiFunctions: React.FC<ApiFunctionsProps> = () => {
 
   const localStorageRemove = async () => {
     try {
-      await extensionHost.localStorageRemoveItem("testbed")
-      updateMessages("Success")
-    } catch(error) {
+      await extensionSDK.localStorageRemoveItem('testbed')
+      updateMessages('Success')
+    } catch (error) {
       updateMessages(error)
       console.error(error)
     }
   }
 
   const trackActionClick = () => {
-    extensionHost.track('click', 'kitchensink-action-tracked')
-    updateMessages("Action tracked")
+    extensionSDK.track('click', 'kitchensink-action-tracked')
+    updateMessages('Action tracked')
   }
 
   const generateUnhandledErrorClick = () => {
-    updateMessages("About to generate error")
+    updateMessages('About to generate error')
     // const badApi: any = {}
     // badApi.noExistentMethod()
-    throw new Error("Kitchensink threw an error")
+    throw new Error('Kitchensink threw an error')
   }
 
   const testRouting = () => {
@@ -138,9 +137,9 @@ export const ApiFunctions: React.FC<ApiFunctionsProps> = () => {
   return (
     <>
       <Heading mt="xlarge">API Functions</Heading>
-      <SandboxStatus/>
-      <Box display="flex" flexDirection="row" >
-        <Box display="flex" flexDirection="column" width="50%" maxWidth='40vw'>
+      <SandboxStatus />
+      <Box display="flex" flexDirection="row">
+        <Box display="flex" flexDirection="column" width="50%" maxWidth="40vw">
           <ExtensionButton
             mt="small"
             variant="outline"
@@ -169,7 +168,11 @@ export const ApiFunctions: React.FC<ApiFunctionsProps> = () => {
           >
             Open marketplace new window
           </ExtensionButton>
-          <ExtensionButton mt="small" variant="outline" onClick={verifyHostConnectionClick}>
+          <ExtensionButton
+            mt="small"
+            variant="outline"
+            onClick={verifyHostConnectionClick}
+          >
             Verify host connection
           </ExtensionButton>
           <ExtensionButton
@@ -207,11 +210,7 @@ export const ApiFunctions: React.FC<ApiFunctionsProps> = () => {
           >
             Generate unhandled error
           </ExtensionButton>
-          <ExtensionButton
-            mt="small"
-            variant="outline"
-            onClick={testRouting}
-          >
+          <ExtensionButton mt="small" variant="outline" onClick={testRouting}>
             Route test
           </ExtensionButton>
           <ExtensionButton
@@ -222,7 +221,7 @@ export const ApiFunctions: React.FC<ApiFunctionsProps> = () => {
             Clear messages
           </ExtensionButton>
         </Box>
-        <Box width="50%" pr="large" maxWidth='40vw'>
+        <Box width="50%" pr="large" maxWidth="40vw">
           <StyledPre>{messages}</StyledPre>
         </Box>
       </Box>

--- a/src/components/Configure/Configure.tsx
+++ b/src/components/Configure/Configure.tsx
@@ -1,0 +1,250 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Looker Data Sciences, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import React, { useContext, useEffect, useState } from 'react'
+import {
+  Button,
+  ButtonOutline,
+  Form,
+  FieldCheckbox,
+  FieldText,
+  Heading,
+  SpaceVertical,
+  ValidationMessages,
+} from '@looker/components'
+import {
+  ExtensionContext,
+  ExtensionContextData,
+} from '@looker/extension-sdk-react'
+import { SandboxStatus } from '../SandboxStatus'
+import { ConfigureProps } from './types'
+import { ConfigurationData } from '../../types'
+
+export const Configure: React.FC<ConfigureProps> = ({
+  configurationData,
+  updateConfigurationData,
+}) => {
+  const [localConfigurationData, setLocalConfigurationData] = useState<
+    ConfigurationData
+  >({ dashboardId: '', exploreId: '', lookId: '' } as ConfigurationData)
+  const extensionContext = useContext<ExtensionContextData>(ExtensionContext)
+  const { extensionSDK } = extensionContext
+
+  useEffect(() => {
+    const initialize = async () => {
+      try {
+        const contextData = await extensionSDK.refreshContextData()
+        if (contextData) {
+          setLocalConfigurationData(contextData as ConfigurationData)
+        }
+      } catch (error) {
+        console.error('failed to get latest context data', error)
+      }
+    }
+    setLocalConfigurationData({ ...configurationData })
+    initialize()
+  }, [])
+
+  const toggleApiFunctions = () => {
+    localConfigurationData.showApiFunctions = !localConfigurationData.showApiFunctions
+    setLocalConfigurationData({ ...localConfigurationData })
+  }
+
+  const toggleCoreSdkFunctions = () => {
+    localConfigurationData.showCoreSdkFunctions = !localConfigurationData.showCoreSdkFunctions
+    setLocalConfigurationData({ ...localConfigurationData })
+  }
+
+  const toggleEmbedDashboard = () => {
+    localConfigurationData.showEmbedDashboard = !localConfigurationData.showEmbedDashboard
+    setLocalConfigurationData({ ...localConfigurationData })
+  }
+
+  const toggleEmbedExplore = () => {
+    localConfigurationData.showEmbedExplore = !localConfigurationData.showEmbedExplore
+    setLocalConfigurationData({ ...localConfigurationData })
+  }
+
+  const toggleEmbedLook = () => {
+    localConfigurationData.showEmbedLook = !localConfigurationData.showEmbedLook
+    setLocalConfigurationData({ ...localConfigurationData })
+  }
+
+  const toggleExternalApiFunctions = () => {
+    localConfigurationData.showExternalApiFunctions = !localConfigurationData.showExternalApiFunctions
+    setLocalConfigurationData({ ...localConfigurationData })
+  }
+
+  const toggleMiscFunctions = () => {
+    localConfigurationData.showMiscFunctions = !localConfigurationData.showMiscFunctions
+    setLocalConfigurationData({ ...localConfigurationData })
+  }
+
+  const validateValue = (value: string): number | string => {
+    if (value.match(/\d+/g)) {
+      return parseInt(value, 10)
+    } else {
+      return value
+    }
+  }
+
+  const changeDashboardId = (event: React.ChangeEvent<HTMLInputElement>) => {
+    localConfigurationData.dashboardId = validateValue(
+      event.currentTarget.value
+    )
+    setLocalConfigurationData({ ...localConfigurationData })
+  }
+
+  const changeExploreId = (event: React.ChangeEvent<HTMLInputElement>) => {
+    localConfigurationData.exploreId = event.currentTarget.value
+    setLocalConfigurationData({ ...localConfigurationData })
+  }
+
+  const changeLookId = (event: React.ChangeEvent<HTMLInputElement>) => {
+    localConfigurationData.lookId = validateValue(event.currentTarget.value)
+    setLocalConfigurationData({ ...localConfigurationData })
+  }
+
+  const getValidationMessages = (): ValidationMessages | undefined => {
+    let validationMessages: ValidationMessages | undefined = undefined
+    if (typeof localConfigurationData.dashboardId === 'string') {
+      if (!validationMessages) {
+        validationMessages = {}
+      }
+      validationMessages['dashboardId'] = {
+        type: 'error',
+        message: 'dashboard id is not numeric',
+      }
+    }
+    if (localConfigurationData.exploreId === '') {
+      if (!validationMessages) {
+        validationMessages = {}
+      }
+      validationMessages['exploreId'] = {
+        type: 'error',
+        message: 'explore id is empty',
+      }
+    }
+    if (typeof localConfigurationData.lookId === 'string') {
+      if (!validationMessages) {
+        validationMessages = {}
+      }
+      validationMessages['lookId'] = {
+        type: 'error',
+        message: 'look id is not numeric',
+      }
+    }
+    return validationMessages
+  }
+
+  const onConfigChangeSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    updateConfigurationData({ ...localConfigurationData })
+  }
+
+  const onConfigResetClick = () => {
+    setLocalConfigurationData({ ...configurationData })
+  }
+
+  const validationMessages = getValidationMessages()
+
+  return (
+    <>
+      <Heading mt="xlarge">Configuration</Heading>
+      <SandboxStatus />
+      <Form
+        width="50%"
+        validationMessages={validationMessages}
+        onSubmit={onConfigChangeSubmit}
+      >
+        <FieldCheckbox
+          label="Show api functions"
+          name="showApiFunctions"
+          checked={localConfigurationData.showApiFunctions}
+          onChange={toggleApiFunctions}
+        />
+        <FieldCheckbox
+          label="Show core sdk functions"
+          name="showCoreSdkFunctions"
+          checked={localConfigurationData.showCoreSdkFunctions}
+          onChange={toggleCoreSdkFunctions}
+        />
+        <FieldCheckbox
+          label="Show embed dashboard"
+          name="showEmbedDashboard"
+          checked={localConfigurationData.showEmbedDashboard}
+          onChange={toggleEmbedDashboard}
+        />
+        <FieldCheckbox
+          label="Show embed explore"
+          name="showEmbedExplore"
+          checked={localConfigurationData.showEmbedExplore}
+          onChange={toggleEmbedExplore}
+        />
+        <FieldCheckbox
+          label="Show embed look"
+          name="showEmbedLook"
+          checked={localConfigurationData.showEmbedLook}
+          onChange={toggleEmbedLook}
+        />
+        <FieldCheckbox
+          label="Show external api functions"
+          name="showExternalApiFunctions"
+          checked={localConfigurationData.showExternalApiFunctions}
+          onChange={toggleExternalApiFunctions}
+        />
+        <FieldCheckbox
+          label="Show miscellaneous functions"
+          name="showMiscFunctions"
+          checked={localConfigurationData.showMiscFunctions}
+          onChange={toggleMiscFunctions}
+        />
+        <FieldText
+          label="Dashboard id"
+          name="dashboardId"
+          value={localConfigurationData.dashboardId}
+          onChange={changeDashboardId}
+        />
+        <FieldText
+          label="Explore id"
+          name="exploreId"
+          value={localConfigurationData.exploreId}
+          onChange={changeExploreId}
+        />
+        <FieldText
+          label="Look id"
+          name="lookId"
+          value={localConfigurationData.lookId}
+          onChange={changeLookId}
+        />
+        <Button disabled={!!validationMessages}>Save configuration</Button>
+      </Form>
+      <SpaceVertical width="50%">
+        <ButtonOutline onClick={onConfigResetClick}>
+          Reset configuration
+        </ButtonOutline>
+      </SpaceVertical>
+    </>
+  )
+}

--- a/src/components/Configure/index.ts
+++ b/src/components/Configure/index.ts
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Looker Data Sciences, Inc.
+ * Copyright (c) 2020 Looker Data Sciences, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,23 +22,5 @@
  * THE SOFTWARE.
  */
 
-import React, { useState } from 'react'
-import { KitchenSink } from './KitchenSink'
-import { ExtensionProvider } from '@looker/extension-sdk-react'
-import { hot } from 'react-hot-loader/root'
-
-export const App: React.FC<{}> = hot(() => {
-  const [route, setRoute] = useState('')
-  const [routeState, setRouteState] = useState()
-
-  const onRouteChange = (route: string, routeState?: any) => {
-    setRoute(route)
-    setRouteState(routeState)
-  }
-
-  return (
-    <ExtensionProvider onRouteChange={onRouteChange}>
-      <KitchenSink route={route} routeState={routeState} />
-    </ExtensionProvider>
-  )
-})
+export * from './Configure'
+export * from './types'

--- a/src/components/Configure/types.ts
+++ b/src/components/Configure/types.ts
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Looker Data Sciences, Inc.
+ * Copyright (c) 2020 Looker Data Sciences, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,23 +22,12 @@
  * THE SOFTWARE.
  */
 
-import React, { useState } from 'react'
-import { KitchenSink } from './KitchenSink'
-import { ExtensionProvider } from '@looker/extension-sdk-react'
-import { hot } from 'react-hot-loader/root'
+import React from 'react'
+import { ConfigurationData } from '../../types'
 
-export const App: React.FC<{}> = hot(() => {
-  const [route, setRoute] = useState('')
-  const [routeState, setRouteState] = useState()
-
-  const onRouteChange = (route: string, routeState?: any) => {
-    setRoute(route)
-    setRouteState(routeState)
-  }
-
-  return (
-    <ExtensionProvider onRouteChange={onRouteChange}>
-      <KitchenSink route={route} routeState={routeState} />
-    </ExtensionProvider>
-  )
-})
+export interface ConfigureProps {
+  configurationData: ConfigurationData
+  updateConfigurationData(
+    configurationData: ConfigurationData
+  ): Promise<boolean>
+}

--- a/src/components/Embed/EmbedDashboard.tsx
+++ b/src/components/Embed/EmbedDashboard.tsx
@@ -22,18 +22,18 @@
  * THE SOFTWARE.
  */
 
-import React, { useCallback, useContext } from "react"
-import { EmbedProps } from "./types"
+import React, { useCallback, useContext } from 'react'
+import { EmbedProps } from './types'
 import { LookerEmbedSDK, LookerEmbedDashboard } from '@looker/embed-sdk'
 import {
   ExtensionContext,
   ExtensionContextData,
-} from "@looker/extension-sdk-react"
-import { Button, Heading, Label, ToggleSwitch } from "@looker/components"
+} from '@looker/extension-sdk-react'
+import { Button, Heading, Label, ToggleSwitch } from '@looker/components'
 import { SandboxStatus } from '../SandboxStatus'
 import { EmbedContainer } from './components/EmbedContainer'
 
-export const EmbedDashboard: React.FC<EmbedProps> = () => {
+export const EmbedDashboard: React.FC<EmbedProps> = ({ id }) => {
   const [dashboardNext, setDashboardNext] = React.useState(true)
   const [running, setRunning] = React.useState(true)
   const [dashboard, setDashboard] = React.useState<LookerEmbedDashboard>()
@@ -55,31 +55,34 @@ export const EmbedDashboard: React.FC<EmbedProps> = () => {
     setDashboard(dashboard)
   }
 
-  const embedCtrRef = useCallback(el => {
-    const hostUrl = extensionContext?.extensionSDK?.lookerHostData?.hostUrl
-    if (el && hostUrl) {
-      el.innerHTML = ''
-      LookerEmbedSDK.init(hostUrl)
-      const db = LookerEmbedSDK.createDashboardWithId(1)
-      if (dashboardNext) {
-        db.withNext()
+  const embedCtrRef = useCallback(
+    (el) => {
+      const hostUrl = extensionContext?.extensionSDK?.lookerHostData?.hostUrl
+      if (el && hostUrl) {
+        el.innerHTML = ''
+        LookerEmbedSDK.init(hostUrl)
+        const db = LookerEmbedSDK.createDashboardWithId(id as number)
+        if (dashboardNext) {
+          db.withNext()
+        }
+        db.appendTo(el)
+          .on('dashboard:loaded', updateRunButton.bind(null, false))
+          .on('dashboard:run:start', updateRunButton.bind(null, true))
+          .on('dashboard:run:complete', updateRunButton.bind(null, false))
+          .on('drillmenu:click', canceller)
+          .on('drillmodal:explore', canceller)
+          .on('dashboard:tile:explore', canceller)
+          .on('dashboard:tile:view', canceller)
+          .build()
+          .connect()
+          .then(setupDashboard)
+          .catch((error: Error) => {
+            console.error('Connection error', error)
+          })
       }
-      db.appendTo(el)
-        .on('dashboard:loaded', updateRunButton.bind(null, false))
-        .on('dashboard:run:start', updateRunButton.bind(null, true))
-        .on('dashboard:run:complete', updateRunButton.bind(null, false))
-        .on('drillmenu:click', canceller)
-        .on('drillmodal:explore', canceller)
-        .on('dashboard:tile:explore', canceller)
-        .on('dashboard:tile:view', canceller)
-        .build()
-        .connect()
-        .then(setupDashboard)
-        .catch((error: Error) => {
-          console.error('Connection error', error)
-        })
-    }
-  }, [dashboardNext])
+    },
+    [dashboardNext]
+  )
 
   const runDashboard = () => {
     if (dashboard) {
@@ -90,13 +93,20 @@ export const EmbedDashboard: React.FC<EmbedProps> = () => {
   return (
     <>
       <Heading mt="xlarge">Embedded Dashboard</Heading>
-      <SandboxStatus/>
+      <SandboxStatus />
       <Label htmlFor="toggle">
         Dashboard next
-        <ToggleSwitch ml='small' onChange={toggleDashboard} on={dashboardNext} id='toggle'/>
+        <ToggleSwitch
+          ml="small"
+          onChange={toggleDashboard}
+          on={dashboardNext}
+          id="toggle"
+        />
       </Label>
-      <Button m='medium' onClick={runDashboard} disabled={running}>Run Dashboard</Button>
-      <EmbedContainer ref={embedCtrRef}/>
+      <Button m="medium" onClick={runDashboard} disabled={running}>
+        Run Dashboard
+      </Button>
+      <EmbedContainer ref={embedCtrRef} />
     </>
   )
 }

--- a/src/components/Embed/EmbedExplore.tsx
+++ b/src/components/Embed/EmbedExplore.tsx
@@ -22,18 +22,18 @@
  * THE SOFTWARE.
  */
 
-import React, { useCallback, useContext } from "react"
-import { EmbedProps } from "./types"
+import React, { useCallback, useContext } from 'react'
+import { EmbedProps } from './types'
 import { LookerEmbedSDK, LookerEmbedExplore } from '@looker/embed-sdk'
 import { SandboxStatus } from '../SandboxStatus'
 import { EmbedContainer } from './components/EmbedContainer'
 import {
   ExtensionContext,
   ExtensionContextData,
-} from "@looker/extension-sdk-react"
-import { Button, Heading } from "@looker/components"
+} from '@looker/extension-sdk-react'
+import { Button, Heading } from '@looker/components'
 
-export const EmbedExplore: React.FC<EmbedProps> = () => {
+export const EmbedExplore: React.FC<EmbedProps> = ({ id }) => {
   const [running, setRunning] = React.useState(true)
   const [explore, setExplore] = React.useState<LookerEmbedExplore>()
   const extensionContext = useContext<ExtensionContextData>(ExtensionContext)
@@ -46,11 +46,11 @@ export const EmbedExplore: React.FC<EmbedProps> = () => {
     setExplore(explore)
   }
 
-  const embedCtrRef = useCallback(el => {
+  const embedCtrRef = useCallback((el) => {
     const hostUrl = extensionContext?.extensionSDK?.lookerHostData?.hostUrl
     if (el && hostUrl) {
       LookerEmbedSDK.init(hostUrl)
-      LookerEmbedSDK.createExploreWithId('thelook/products')
+      LookerEmbedSDK.createExploreWithId(id as string)
         .appendTo(el)
         .on('explore:ready', updateRunButton.bind(null, false))
         .on('explore:run:start', updateRunButton.bind(null, true))
@@ -73,9 +73,11 @@ export const EmbedExplore: React.FC<EmbedProps> = () => {
   return (
     <>
       <Heading mt="xlarge">Embedded Explore</Heading>
-      <SandboxStatus/>
-      <Button m='medium' onClick={runExplore} disabled={running}>Run Explore</Button>
-      <EmbedContainer ref={embedCtrRef}/>
+      <SandboxStatus />
+      <Button m="medium" onClick={runExplore} disabled={running}>
+        Run Explore
+      </Button>
+      <EmbedContainer ref={embedCtrRef} />
     </>
   )
 }

--- a/src/components/Embed/EmbedLook.tsx
+++ b/src/components/Embed/EmbedLook.tsx
@@ -22,18 +22,18 @@
  * THE SOFTWARE.
  */
 
-import React, { useCallback, useContext } from "react"
-import { EmbedProps } from "./types"
+import React, { useCallback, useContext } from 'react'
+import { EmbedProps } from './types'
 import { LookerEmbedSDK, LookerEmbedLook } from '@looker/embed-sdk'
 import { SandboxStatus } from '../SandboxStatus'
 import { EmbedContainer } from './components/EmbedContainer'
 import {
   ExtensionContext,
   ExtensionContextData,
-} from "@looker/extension-sdk-react"
-import { Button, Heading } from "@looker/components"
+} from '@looker/extension-sdk-react'
+import { Button, Heading } from '@looker/components'
 
-export const EmbedLook: React.FC<EmbedProps> = () => {
+export const EmbedLook: React.FC<EmbedProps> = ({ id }) => {
   const [running, setRunning] = React.useState(true)
   const [look, setLook] = React.useState<LookerEmbedLook>()
   const extensionContext = useContext<ExtensionContextData>(ExtensionContext)
@@ -46,11 +46,11 @@ export const EmbedLook: React.FC<EmbedProps> = () => {
     setLook(look)
   }
 
-  const embedCtrRef = useCallback(el => {
+  const embedCtrRef = useCallback((el) => {
     const hostUrl = extensionContext?.extensionSDK?.lookerHostData?.hostUrl
     if (el && hostUrl) {
       LookerEmbedSDK.init(hostUrl)
-      LookerEmbedSDK.createLookWithId(2)
+      LookerEmbedSDK.createLookWithId(id as number)
         .appendTo(el)
         .on('look:loaded', updateRunButton.bind(null, false))
         .on('look:run:start', updateRunButton.bind(null, true))
@@ -73,9 +73,11 @@ export const EmbedLook: React.FC<EmbedProps> = () => {
   return (
     <>
       <Heading mt="xlarge">Embedded Look</Heading>
-      <SandboxStatus/>
-      <Button m='medium' onClick={runLook} disabled={running}>Run Look</Button>
-      <EmbedContainer ref={embedCtrRef}/>
+      <SandboxStatus />
+      <Button m="medium" onClick={runLook} disabled={running}>
+        Run Look
+      </Button>
+      <EmbedContainer ref={embedCtrRef} />
     </>
   )
 }

--- a/src/components/Embed/types.ts
+++ b/src/components/Embed/types.ts
@@ -22,4 +22,6 @@
  * THE SOFTWARE.
  */
 
-export interface EmbedProps {}
+export interface EmbedProps {
+  id: number | string
+}

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -1,0 +1,83 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Looker Data Sciences, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import React, { useEffect, useState } from 'react'
+import { Heading, Paragraph, SpaceVertical } from '@looker/components'
+import { SandboxStatus } from '../SandboxStatus'
+import { HomeProps } from './types'
+
+export const Home: React.FC<HomeProps> = () => {
+  return (
+    <>
+      <Heading mt="xlarge">Home</Heading>
+      <SandboxStatus />
+      <SpaceVertical>
+        <Paragraph>
+          Welcome to the kitchen sink which demonstrates how to exercise the
+          capabilities of the extension framework.
+        </Paragraph>
+        <Paragraph>
+          The <b>Api Functions view</b> demonstrates the basic capabilties of
+          the extension, for example navigation, local storage access.
+        </Paragraph>
+        <Paragraph>
+          The <b>Core Functions view</b> demonstrates using the Looker core API.
+        </Paragraph>
+        <Paragraph>
+          The <b>Embed Dashbbord view</b> demonstrates using the embed SDK to
+          display an embedded dashboard in an extension.
+        </Paragraph>
+        <Paragraph>
+          The <b>Embed Explore view</b> demonstrates using the embed SDK to
+          display an embedded explore in an extension.
+        </Paragraph>
+        <Paragraph>
+          The <b>Embed Look view</b> demonstrates using the embed SDK to display
+          an embedded look in an extension.
+        </Paragraph>
+        <Paragraph>
+          The <b>External Api Functions view</b> demonstrates various ways to
+          access external APIs from an extrnsion. It also demonstrates how to
+          integrate with OAUTH2 providers. Note that a data server is required
+          to exercise this functionality. Running{' '}
+          <code>yarn start-data-server</code> from your work space starts the
+          data server.
+        </Paragraph>
+        <Paragraph>
+          The <b>Miscellaneous view</b> demonstrates unclassifiable
+          functionality of the extension layout. An example is how the framework
+          handles an attempt to navigate away from the initial extension page
+          (it reloads the extension). It also shows a specialized logout button
+          for <b>Spartan</b> extensions (extensions that run with the Looker
+          chrome).
+        </Paragraph>
+        <Paragraph>
+          The <b>Configuration view</b> demonstrates how to use the extension
+          context API to save configuration data. Basically views can be hidden
+          or shown. Default ids can be overridden for embed views.
+        </Paragraph>
+      </SpaceVertical>
+    </>
+  )
+}

--- a/src/components/Home/index.ts
+++ b/src/components/Home/index.ts
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Looker Data Sciences, Inc.
+ * Copyright (c) 2020 Looker Data Sciences, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,23 +22,5 @@
  * THE SOFTWARE.
  */
 
-import React, { useState } from 'react'
-import { KitchenSink } from './KitchenSink'
-import { ExtensionProvider } from '@looker/extension-sdk-react'
-import { hot } from 'react-hot-loader/root'
-
-export const App: React.FC<{}> = hot(() => {
-  const [route, setRoute] = useState('')
-  const [routeState, setRouteState] = useState()
-
-  const onRouteChange = (route: string, routeState?: any) => {
-    setRoute(route)
-    setRouteState(routeState)
-  }
-
-  return (
-    <ExtensionProvider onRouteChange={onRouteChange}>
-      <KitchenSink route={route} routeState={routeState} />
-    </ExtensionProvider>
-  )
-})
+export * from './Home'
+export * from './types'

--- a/src/components/Home/types.ts
+++ b/src/components/Home/types.ts
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Looker Data Sciences, Inc.
+ * Copyright (c) 2020 Looker Data Sciences, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,23 +22,6 @@
  * THE SOFTWARE.
  */
 
-import React, { useState } from 'react'
-import { KitchenSink } from './KitchenSink'
-import { ExtensionProvider } from '@looker/extension-sdk-react'
-import { hot } from 'react-hot-loader/root'
+import React from 'react'
 
-export const App: React.FC<{}> = hot(() => {
-  const [route, setRoute] = useState('')
-  const [routeState, setRouteState] = useState()
-
-  const onRouteChange = (route: string, routeState?: any) => {
-    setRoute(route)
-    setRouteState(routeState)
-  }
-
-  return (
-    <ExtensionProvider onRouteChange={onRouteChange}>
-      <KitchenSink route={route} routeState={routeState} />
-    </ExtensionProvider>
-  )
-})
+export interface HomeProps {}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -28,63 +28,81 @@ import { Link as RouterLink, LinkProps } from 'react-router-dom'
 import styled from 'styled-components'
 import { SidebarProps } from './'
 import omit from 'lodash/omit'
-import { ROUTES } from '../../App'
+import { ROUTES } from '../../KitchenSink'
 
-export const Sidebar: React.FC<SidebarProps> = ({ route }) => {
+export const Sidebar: React.FC<SidebarProps> = ({
+  route,
+  configurationData,
+}) => {
   return (
     <Box display="flex" flexDirection="column">
       <MenuGroup type="none">
-        <StyledRouterLink to={ROUTES.API_ROUTE}>
-          <MenuItem icon="Flag" current={route === ROUTES.API_ROUTE}>
-            Api Functions
+        <StyledRouterLink to={ROUTES.HOME_ROUTE}>
+          <MenuItem icon="Home" current={route === ROUTES.HOME_ROUTE}>
+            Home
           </MenuItem>
         </StyledRouterLink>
-        <StyledRouterLink to={ROUTES.CORESDK_ROUTE}>
-          <MenuItem
-            icon="Clock"
-            current={route.startsWith(ROUTES.CORESDK_ROUTE)}
-          >
-            Core SDK Functions
-          </MenuItem>
-        </StyledRouterLink>
-        <StyledRouterLink to={ROUTES.EMBED_DASHBOARD}>
-          <MenuItem
-            icon="ApplicationSelect"
-            current={route === ROUTES.EMBED_DASHBOARD}
-          >
-            Embed Dashboard
-          </MenuItem>
-        </StyledRouterLink>
-        <StyledRouterLink to={ROUTES.EMBED_EXPLORE}>
-          <MenuItem
-            icon="ApplicationSelect"
-            current={route === ROUTES.EMBED_EXPLORE}
-          >
-            Embed Explore
-          </MenuItem>
-        </StyledRouterLink>
-        <StyledRouterLink to={ROUTES.EMBED_LOOK}>
-          <MenuItem
-            icon="ApplicationSelect"
-            current={route === ROUTES.EMBED_LOOK}
-          >
-            Embed Look
-          </MenuItem>
-        </StyledRouterLink>
-        <StyledRouterLink to={ROUTES.EXTERNAL_API_ROUTE}>
-          <MenuItem
-            icon="ApplicationSelect"
-            current={route.startsWith(ROUTES.EXTERNAL_API_ROUTE)}
-          >
-            External Api Functions
-          </MenuItem>
-        </StyledRouterLink>
-        <StyledRouterLink to={ROUTES.MISC_ROUTE}>
-          <MenuItem
-            icon="ApplicationSelect"
-            current={route === ROUTES.MISC_ROUTE}
-          >
-            Miscellaneous Functions
+        {configurationData.showApiFunctions && (
+          <StyledRouterLink to={ROUTES.API_ROUTE}>
+            <MenuItem icon="Api" current={route === ROUTES.API_ROUTE}>
+              Api Functions
+            </MenuItem>
+          </StyledRouterLink>
+        )}
+        {configurationData.showCoreSdkFunctions && (
+          <StyledRouterLink to={ROUTES.CORESDK_ROUTE}>
+            <MenuItem
+              icon="SqlRunner"
+              current={route.startsWith(ROUTES.CORESDK_ROUTE)}
+            >
+              Core SDK Functions
+            </MenuItem>
+          </StyledRouterLink>
+        )}
+        {configurationData.showEmbedDashboard && (
+          <StyledRouterLink to={ROUTES.EMBED_DASHBOARD}>
+            <MenuItem
+              icon="Dashboard"
+              current={route === ROUTES.EMBED_DASHBOARD}
+            >
+              Embed Dashboard
+            </MenuItem>
+          </StyledRouterLink>
+        )}
+        {configurationData.showEmbedExplore && (
+          <StyledRouterLink to={ROUTES.EMBED_EXPLORE}>
+            <MenuItem icon="Explore" current={route === ROUTES.EMBED_EXPLORE}>
+              Embed Explore
+            </MenuItem>
+          </StyledRouterLink>
+        )}
+        {configurationData.showEmbedLook && (
+          <StyledRouterLink to={ROUTES.EMBED_LOOK}>
+            <MenuItem icon="AnalyticsApp" current={route === ROUTES.EMBED_LOOK}>
+              Embed Look
+            </MenuItem>
+          </StyledRouterLink>
+        )}
+        {configurationData.showExternalApiFunctions && (
+          <StyledRouterLink to={ROUTES.EXTERNAL_API_ROUTE}>
+            <MenuItem
+              icon="External"
+              current={route.startsWith(ROUTES.EXTERNAL_API_ROUTE)}
+            >
+              External Api Functions
+            </MenuItem>
+          </StyledRouterLink>
+        )}
+        {configurationData.showMiscFunctions && (
+          <StyledRouterLink to={ROUTES.MISC_ROUTE}>
+            <MenuItem icon="More" current={route === ROUTES.MISC_ROUTE}>
+              Miscellaneous Functions
+            </MenuItem>
+          </StyledRouterLink>
+        )}
+        <StyledRouterLink to={ROUTES.CONFIG_ROUTE}>
+          <MenuItem icon="Gear" current={route === ROUTES.CONFIG_ROUTE}>
+            Configure
           </MenuItem>
         </StyledRouterLink>
       </MenuGroup>

--- a/src/components/Sidebar/types.ts
+++ b/src/components/Sidebar/types.ts
@@ -22,7 +22,10 @@
  * THE SOFTWARE.
  */
 
+import { ConfigurationData } from '../../types'
+
 export interface SidebarProps {
   route: string
   routeState?: any
+  configurationData: ConfigurationData
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,12 +22,12 @@
  * THE SOFTWARE.
  */
 
-import * as React from "react"
-import * as ReactDOM from "react-dom"
-import { App } from "./App"
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import { App } from './App'
 
-window.addEventListener("DOMContentLoaded", event => {
-  var root = document.createElement("div")
+window.addEventListener('DOMContentLoaded', (event) => {
+  var root = document.createElement('div')
   document.body.appendChild(root)
   ReactDOM.render(<App />, root)
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Looker Data Sciences, Inc.
+ * Copyright (c) 2020 Looker Data Sciences, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,23 +22,20 @@
  * THE SOFTWARE.
  */
 
-import React, { useState } from 'react'
-import { KitchenSink } from './KitchenSink'
-import { ExtensionProvider } from '@looker/extension-sdk-react'
-import { hot } from 'react-hot-loader/root'
+export interface KitchenSinkProps {
+  route: string
+  routeState?: any
+}
 
-export const App: React.FC<{}> = hot(() => {
-  const [route, setRoute] = useState('')
-  const [routeState, setRouteState] = useState()
-
-  const onRouteChange = (route: string, routeState?: any) => {
-    setRoute(route)
-    setRouteState(routeState)
-  }
-
-  return (
-    <ExtensionProvider onRouteChange={onRouteChange}>
-      <KitchenSink route={route} routeState={routeState} />
-    </ExtensionProvider>
-  )
-})
+export interface ConfigurationData {
+  showApiFunctions: boolean
+  showCoreSdkFunctions: boolean
+  showEmbedDashboard: boolean
+  showEmbedExplore: boolean
+  showEmbedLook: boolean
+  showExternalApiFunctions: boolean
+  showMiscFunctions: boolean
+  dashboardId: number | string
+  exploreId: string
+  lookId: number | string
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1011,17 +1011,17 @@
   dependencies:
     "@looker/chatty" "^2.2.0"
 
-"@looker/extension-sdk-react@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@looker/extension-sdk-react/-/extension-sdk-react-0.6.1.tgz#ae0d13c07de4ff957b74157b69b77bbab4497ab9"
-  integrity sha512-hHcpxRmaEoreGlBFvqpaAUuoOpVNXx0ekKzATdByv0KWpRLAWoqF8Z7BZnosLvU/f0mSWOLYCxWHj11VJVzFwQ==
+"@looker/extension-sdk-react@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@looker/extension-sdk-react/-/extension-sdk-react-0.6.2.tgz#c447f7a2b2bb83ca831705b0e6637656fbc7605a"
+  integrity sha512-4FJbWdyBsY8tWp3cM7lh6PtZE6i41hxiXdW+bjr0Ln8BooWwO8J3DDIatO3s3LIxZhPWs2XfmB7mw7GP+ATYPw==
   dependencies:
     ts-loader "^6.1.2"
 
-"@looker/extension-sdk@^0.10.5":
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/@looker/extension-sdk/-/extension-sdk-0.10.5.tgz#b7723a86740ada6a420428e43bf646e3cb1b7522"
-  integrity sha512-ishgUBbK+c1OYsdJTbxLtOBW6ND9UYF7PUuDOBSzBs0HGRcg2BLJEB8Ii/S9zwB1f1W4xzDwWFo6lWSzgX5fzg==
+"@looker/extension-sdk@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@looker/extension-sdk/-/extension-sdk-0.11.0.tgz#bb1f7d908180d97e6acf46824e67c82d6c00c132"
+  integrity sha512-KRgGFOl9kbge+QZIQTUhtVVZrP9EZBtRlS7if+KnlAJ+k8Xp4AEHlBmswAxZTGWra//Be8DZVESj2xT1olebIg==
   dependencies:
     "@looker/chatty" "^2.2.0"
     "@looker/sdk" "0.3.0-beta.1"


### PR DESCRIPTION
A configuration view has been added that allows a user to show/hide other views and to override the keys for the embed views which were hard coded. A new home page has been added that shows some blurb about what the Kitchen Sink does. Neither the configuration view or the home view can be hidden. The example is contrived as normally the configuration would be restricted to some kind of administrator.

The App component has been split into two components, App and KitchenSink. This has been done as the KitchenSink needs access to context data. App is now a very simple component that wraps the KitchenSink component in the ExtensionProvider. This allows the KitchenSink to access the context without the ugliness (at least in my opinion) that would need to happen if the code remained in the App component.

![image](https://user-images.githubusercontent.com/3278565/88940523-b2ed7a80-d23c-11ea-8128-7d5fbdffa09c.png)

![image](https://user-images.githubusercontent.com/3278565/88940557-bda80f80-d23c-11ea-9a24-c784b91a7d9c.png)
